### PR TITLE
Add webhook server feature

### DIFF
--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -531,6 +531,15 @@ async fn schedule_mcp_start_task<R: Runtime>(
         cmd.arg("run");
         cmd.env("UV_CACHE_DIR", cache_dir.to_str().unwrap().to_string());
     }
+
+    if command == "bunx" {
+        let mut cache_dir = app_path.clone();
+        cache_dir.push(".bunx");
+        let bun_path = format!("{}/bun", bin_path.display());
+        cmd = Command::new(bun_path);
+        cmd.arg("x");
+        cmd.env("BUN_INSTALL", cache_dir.to_str().unwrap().to_string());
+    }
     
     #[cfg(windows)]
     {

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -7,3 +7,4 @@ pub mod setup;
 pub mod state;
 pub mod threads;
 pub mod utils;
+pub mod webhook;

--- a/src-tauri/src/core/state.rs
+++ b/src-tauri/src/core/state.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::{HashMap, VecDeque}, sync::Arc};
 
 use crate::core::utils::download::DownloadManagerState;
 use rand::{distributions::Alphanumeric, Rng};
@@ -20,6 +20,8 @@ pub struct AppState {
     pub mcp_active_servers: Arc<Mutex<HashMap<String, serde_json::Value>>>,
     pub mcp_successfully_connected: Arc<Mutex<HashMap<String, bool>>>,
     pub server_handle: Arc<Mutex<Option<ServerHandle>>>,
+    pub webhook_handle: Arc<Mutex<Option<ServerHandle>>>,
+    pub webhook_queue: Arc<Mutex<VecDeque<serde_json::Value>>>,
 }
 pub fn generate_app_token() -> String {
     rand::thread_rng()

--- a/src-tauri/src/core/webhook.rs
+++ b/src-tauri/src/core/webhook.rs
@@ -1,0 +1,87 @@
+use std::collections::VecDeque;
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use hyper::{service::{make_service_fn, service_fn}, Body, Method, Request, Response, Server};
+use serde_json::Value;
+use tauri::{AppHandle, State};
+use tokio::{sync::Mutex, task::JoinHandle};
+
+use crate::core::state::{AppState, ServerHandle};
+
+async fn handle_request(
+    req: Request<Body>,
+    queue: Arc<Mutex<VecDeque<Value>>>,
+) -> Result<Response<Body>, Infallible> {
+    if req.method() != Method::POST {
+        return Ok(Response::builder()
+            .status(405)
+            .body(Body::from("Method Not Allowed"))
+            .unwrap());
+    }
+
+    let bytes = hyper::body::to_bytes(req.into_body()).await.unwrap_or_default();
+    if let Ok(json) = serde_json::from_slice::<Value>(&bytes) {
+        let leads = if let Some(arr) = json.as_array() {
+            arr.clone()
+        } else if let Some(obj) = json.as_object() {
+            obj.get("leads")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+
+        let mut q = queue.lock().await;
+        for lead in leads {
+            q.push_back(lead);
+        }
+    }
+
+    Ok(Response::new(Body::from("ok")))
+}
+
+async fn run_server(
+    addr: SocketAddr,
+    queue: Arc<Mutex<VecDeque<Value>>>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let make_svc = make_service_fn(move |_| {
+        let q = queue.clone();
+        async move { Ok::<_, Infallible>(service_fn(move |req| handle_request(req, q.clone()))) }
+    });
+
+    let server = Server::bind(&addr).serve(make_svc);
+    log::info!("Webhook server listening on http://{}", addr);
+    server.await.map_err(|e| e.into())
+}
+
+#[tauri::command]
+pub async fn start_webhook_server(state: State<'_, AppState>, port: u16) -> Result<(), String> {
+    let addr: SocketAddr = format!("0.0.0.0:{}", port)
+        .parse()
+        .map_err(|e| format!("Invalid address: {}", e))?;
+
+    let queue = state.webhook_queue.clone();
+    let handle = tokio::spawn(run_server(addr, queue));
+    let mut h = state.webhook_handle.lock().await;
+    *h = Some(handle);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn stop_webhook_server(state: State<'_, AppState>) -> Result<(), String> {
+    let mut handle = state.webhook_handle.lock().await;
+    if let Some(h) = handle.take() {
+        h.abort();
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_next_lead(state: State<'_, AppState>) -> Option<String> {
+    let mut q = state.webhook_queue.lock().await;
+    q.pop_front().map(|v| v.to_string())
+}
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ use core::{
     state::{generate_app_token, AppState},
     utils::download::DownloadManagerState,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::{HashMap, VecDeque}, sync::Arc};
 
 use tauri::Emitter;
 use tokio::sync::Mutex;
@@ -87,6 +87,9 @@ pub fn run() {
             // hardware
             core::hardware::get_system_info,
             core::hardware::get_system_usage,
+            core::webhook::start_webhook_server,
+            core::webhook::stop_webhook_server,
+            core::webhook::get_next_lead,
         ])
         .manage(AppState {
             app_token: Some(generate_app_token()),
@@ -98,6 +101,8 @@ pub fn run() {
             mcp_active_servers: Arc::new(Mutex::new(HashMap::new())),
             mcp_successfully_connected: Arc::new(Mutex::new(HashMap::new())),
             server_handle: Arc::new(Mutex::new(None)),
+            webhook_handle: Arc::new(Mutex::new(None)),
+            webhook_queue: Arc::new(Mutex::new(VecDeque::new())),
         })
         .setup(|app| {
             app.handle().plugin(

--- a/web-app/src/constants/localStorage.ts
+++ b/web-app/src/constants/localStorage.ts
@@ -8,6 +8,7 @@ export const localStorageKey = {
   settingGeneral: 'setting-general',
   settingCodeBlock: 'setting-code-block',
   settingLocalApiServer: 'setting-local-api-server',
+  settingWebhookServer: 'setting-webhook-server',
   settingProxyConfig: 'setting-proxy-config',
   settingHardware: 'setting-hardware',
   settingVulkan: 'setting-vulkan',

--- a/web-app/src/constants/routes.ts
+++ b/web-app/src/constants/routes.ts
@@ -13,6 +13,7 @@ export const route = {
     shortcuts: '/settings/shortcuts',
     extensions: '/settings/extensions',
     local_api_server: '/settings/local-api-server',
+    webhook_server: '/settings/webhook-server',
     mcp_servers: '/settings/mcp-servers',
     https_proxy: '/settings/https-proxy',
     hardware: '/settings/hardware',

--- a/web-app/src/containers/SettingsMenu.tsx
+++ b/web-app/src/containers/SettingsMenu.tsx
@@ -93,6 +93,10 @@ const SettingsMenu = () => {
       route: route.settings.local_api_server,
     },
     {
+      title: 'common:webhook-server',
+      route: route.settings.webhook_server,
+    },
+    {
       title: 'common:https_proxy',
       route: route.settings.https_proxy,
     },

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -9,11 +9,13 @@ type AppState = {
   loadingModel?: boolean
   tools: MCPTool[]
   serverStatus: 'running' | 'stopped' | 'pending'
+  webhookServerStatus: 'running' | 'stopped' | 'pending'
   abortControllers: Record<string, AbortController>
   tokenSpeed?: TokenSpeed
   currentToolCall?: ChatCompletionMessageToolCall
   showOutOfContextDialog?: boolean
   setServerStatus: (value: 'running' | 'stopped' | 'pending') => void
+  setWebhookServerStatus: (value: 'running' | 'stopped' | 'pending') => void
   updateStreamingContent: (content: ThreadMessage | undefined) => void
   updateCurrentToolCall: (
     toolCall: ChatCompletionMessageToolCall | undefined
@@ -31,6 +33,7 @@ export const useAppState = create<AppState>()((set) => ({
   loadingModel: false,
   tools: [],
   serverStatus: 'stopped',
+  webhookServerStatus: 'stopped',
   abortControllers: {},
   tokenSpeed: undefined,
   currentToolCall: undefined,
@@ -60,6 +63,7 @@ export const useAppState = create<AppState>()((set) => ({
     set({ tools })
   },
   setServerStatus: (value) => set({ serverStatus: value }),
+  setWebhookServerStatus: (value) => set({ webhookServerStatus: value }),
   setAbortController: (threadId, controller) => {
     set((state) => ({
       abortControllers: {

--- a/web-app/src/hooks/useWebhook.ts
+++ b/web-app/src/hooks/useWebhook.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import { localStorageKey } from '@/constants/localStorage'
+
+export const useWebhook = create<{
+  runOnStartup: boolean
+  setRunOnStartup: (v: boolean) => void
+  port: number
+  setPort: (n: number) => void
+}>()(
+  persist(
+    (set) => ({
+      runOnStartup: false,
+      setRunOnStartup: (v) => set({ runOnStartup: v }),
+      port: 8080,
+      setPort: (n) => set({ port: n }),
+    }),
+    { name: localStorageKey.settingWebhookServer, storage: createJSONStorage(() => localStorage) }
+  )
+)

--- a/web-app/src/locales/en/common.json
+++ b/web-app/src/locales/en/common.json
@@ -5,6 +5,7 @@
   "local_api_server": "Local API Server",
   "https_proxy": "HTTPS Proxy",
   "extensions": "Extensions",
+  "webhook-server": "Webhook Server",
   "general": "General",
   "settings": "Settings",
   "modelProviders": "Model Providers",

--- a/web-app/src/routes/settings/webhook-server.tsx
+++ b/web-app/src/routes/settings/webhook-server.tsx
@@ -1,0 +1,66 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { route } from '@/constants/routes'
+import HeaderPage from '@/containers/HeaderPage'
+import SettingsMenu from '@/containers/SettingsMenu'
+import { Card, CardItem } from '@/containers/Card'
+import { PortInput } from '@/containers/PortInput'
+import { Switch } from '@/components/ui/switch'
+import { Button } from '@/components/ui/button'
+import { useWebhook } from '@/hooks/useWebhook'
+import { useAppState } from '@/hooks/useAppState'
+import { useTranslation } from '@/i18n/react-i18next-compat'
+import { useEffect } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+
+export const Route = createFileRoute(route.settings.webhook_server as any)({
+  component: WebhookServer,
+})
+
+function WebhookServer() {
+  const { t } = useTranslation()
+  const { port, setPort, runOnStartup, setRunOnStartup } = useWebhook()
+  const { webhookServerStatus, setWebhookServerStatus } = useAppState()
+
+  useEffect(() => {
+    // placeholder to check status later
+  }, [])
+
+  const toggleServer = async () => {
+    setWebhookServerStatus('pending')
+    if (webhookServerStatus === 'stopped') {
+      await invoke('start_webhook_server', { port })
+        .then(() => setWebhookServerStatus('running'))
+        .catch(() => setWebhookServerStatus('stopped'))
+    } else {
+      await invoke('stop_webhook_server')
+        .catch(() => {})
+      setWebhookServerStatus('stopped')
+    }
+  }
+
+  const isServerRunning = webhookServerStatus === 'running'
+
+  return (
+    <div className="flex h-full">
+      <SettingsMenu />
+      <div className="flex-1 overflow-y-auto p-4">
+        <HeaderPage title={t('common:webhook-server')} />
+        <Card>
+          <CardItem title="Port">
+            <PortInput port={port} setPort={setPort} />
+          </CardItem>
+          <CardItem title="Run on Startup">
+            <Switch checked={runOnStartup} onCheckedChange={setRunOnStartup} />
+          </CardItem>
+          <CardItem>
+            <Button onClick={toggleServer} variant="secondary">
+              {isServerRunning ? 'Stop Server' : 'Start Server'}
+            </Button>
+          </CardItem>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+export default WebhookServer


### PR DESCRIPTION
## Summary
- add webhook server backend
- expose webhook commands and queue in AppState
- allow `bunx` for MCP servers
- add settings UI for webhook server
- wire up UI state with new localStorage key

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_687a3c33faa8832589479256932cec70