### PR TITLE
Add webhook queue processing

### DIFF
--- a/web-app/src/providers/WebhookQueueProvider.tsx
+++ b/web-app/src/providers/WebhookQueueProvider.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { useModelProvider } from '@/hooks/useModelProvider'
+import { useThreads } from '@/hooks/useThreads'
+import { useChat } from '@/hooks/useChat'
+import { useAppState } from '@/hooks/useAppState'
+import { defaultModel } from '@/lib/models'
+
+export function WebhookQueueProvider() {
+  const { selectedProvider, selectedModel } = useModelProvider()
+  const { createThread, setCurrentThreadId } = useThreads()
+  const { sendMessage } = useChat()
+  const { streamingContent } = useAppState()
+  const processingRef = useRef(false)
+
+  useEffect(() => {
+    if (!streamingContent && processingRef.current) {
+      processingRef.current = false
+    }
+  }, [streamingContent])
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      if (processingRef.current) return
+      if (useAppState.getState().streamingContent) return
+      try {
+        const lead = await invoke<string | null>('get_next_lead')
+        if (lead) {
+          processingRef.current = true
+          const thread = await createThread(
+            {
+              id: selectedModel?.id ?? defaultModel(selectedProvider),
+              provider: selectedProvider,
+            },
+            'Webhook Lead'
+          )
+          setCurrentThreadId(thread.id)
+          sendMessage(lead, false)
+        }
+      } catch (e) {
+        console.error('Failed to process webhook lead:', e)
+      }
+    }, 3000)
+    return () => clearInterval(interval)
+  }, [createThread, selectedProvider, selectedModel, setCurrentThreadId, sendMessage])
+
+  return null
+}

--- a/web-app/src/routes/__root.tsx
+++ b/web-app/src/routes/__root.tsx
@@ -9,6 +9,7 @@ import { AppearanceProvider } from '@/providers/AppearanceProvider'
 import { ThemeProvider } from '@/providers/ThemeProvider'
 import { KeyboardShortcutsProvider } from '@/providers/KeyboardShortcuts'
 import { DataProvider } from '@/providers/DataProvider'
+import { WebhookQueueProvider } from '@/providers/WebhookQueueProvider'
 import { route } from '@/constants/routes'
 import { ExtensionProvider } from '@/providers/ExtensionProvider'
 import { ToasterProvider } from '@/providers/ToasterProvider'
@@ -159,6 +160,7 @@ function RootLayout() {
       <TranslationProvider>
         <ExtensionProvider>
           <DataProvider />
+          <WebhookQueueProvider />
         </ExtensionProvider>
         {isLocalAPIServerLogsRoute ? <LogsLayout /> : <AppLayout />}
         {/* <TanStackRouterDevtools position="bottom-right" /> */}

--- a/web-app/src/routes/settings/webhook-server.tsx
+++ b/web-app/src/routes/settings/webhook-server.tsx
@@ -3,7 +3,7 @@ import { route } from '@/constants/routes'
 import HeaderPage from '@/containers/HeaderPage'
 import SettingsMenu from '@/containers/SettingsMenu'
 import { Card, CardItem } from '@/containers/Card'
-import { PortInput } from '@/containers/PortInput'
+import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { Button } from '@/components/ui/button'
 import { useWebhook } from '@/hooks/useWebhook'
@@ -12,6 +12,7 @@ import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useEffect } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Route = createFileRoute(route.settings.webhook_server as any)({
   component: WebhookServer,
 })
@@ -44,19 +45,37 @@ function WebhookServer() {
     <div className="flex h-full">
       <SettingsMenu />
       <div className="flex-1 overflow-y-auto p-4">
-        <HeaderPage title={t('common:webhook-server')} />
+        <HeaderPage>
+          <h1 className="font-medium">{t('common:webhook-server')}</h1>
+        </HeaderPage>
         <Card>
-          <CardItem title="Port">
-            <PortInput port={port} setPort={setPort} />
-          </CardItem>
-          <CardItem title="Run on Startup">
-            <Switch checked={runOnStartup} onCheckedChange={setRunOnStartup} />
-          </CardItem>
-          <CardItem>
-            <Button onClick={toggleServer} variant="secondary">
-              {isServerRunning ? 'Stop Server' : 'Start Server'}
-            </Button>
-          </CardItem>
+          <CardItem
+            title="Port"
+            actions={
+              <Input
+                type="number"
+                min={0}
+                max={65535}
+                value={port}
+                onChange={(e) => setPort(parseInt(e.target.value) || 0)}
+                className="w-24 h-8 text-sm"
+              />
+            }
+          />
+          <CardItem
+            title="Run on Startup"
+            actions={<Switch checked={runOnStartup} onCheckedChange={setRunOnStartup} />}
+          />
+          <CardItem
+            actions={
+              <Button
+                onClick={toggleServer}
+                variant={isServerRunning ? 'destructive' : 'default'}
+              >
+                {isServerRunning ? 'Stop Server' : 'Start Server'}
+              </Button>
+            }
+          />
         </Card>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- create `WebhookQueueProvider` to poll leads from webhook server
- include provider in root layout
- adjust webhook server settings page to use new provider and update UI

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_687a68e1bb4883258964e000575d100b