### PR TITLE
Fix close event listener for Tauri 2

### DIFF
--- a/src-tauri/src/core/setup.rs
+++ b/src-tauri/src/core/setup.rs
@@ -241,7 +241,7 @@ pub fn setup_mcp(app: &App) {
 
     // Add a listener to handle app quit gracefully
     let app_handle_for_quit = app.handle().clone();
-    app.listen_global("tauri://close-requested", move |_event| {
+    app.listen_any("tauri://close-requested", move |_event| {
         let state: tauri::State<AppState> = app_handle_for_quit.state();
         log::info!("App close requested, handling MCP cleanup.");
         // We block on this to ensure cleanup happens before the app fully exits.


### PR DESCRIPTION
## Summary
- adapt MCP setup to Tauri 2 event API

## Testing
- `cargo check` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f43578e048325909ebb061ae2b8fa