### PR TITLE
Fix missing binary path build

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,14 @@ mise dev        # runs the full development setup
 yarn install
 yarn build:core
 yarn build:extensions
+yarn download:bin
 yarn dev
 ```
+
+`yarn download:bin` downloads the Bun and UV binaries into `src-tauri/resources/bin`.
+For macOS, this also creates `bun-universal-apple-darwin` and `uv-universal-apple-darwin`
+alongside the regular `bun` and `uv` executables. Bundling will fail with a message
+like `Failed to copy external binaries` if these files are missing.
 
 ## System Requirements
 

--- a/scripts/download-bin.mjs
+++ b/scripts/download-bin.mjs
@@ -94,8 +94,13 @@ async function handleMacOsUniversal() {
 
   // Create universal binaries using lipo
   console.log('Creating universal binaries with lipo...')
-  execSync(`lipo -create -output ${path.join(BIN_DIR, 'bun')} ${bunX64Path} ${bunAarch64Path}`)
-  execSync(`lipo -create -output ${path.join(BIN_DIR, 'uv')} ${uvX64Path} ${uvAarch64Path}`)
+  const bunUniversal = path.join(BIN_DIR, 'bun-universal-apple-darwin')
+  const uvUniversal = path.join(BIN_DIR, 'uv-universal-apple-darwin')
+  execSync(`lipo -create -output ${bunUniversal} ${bunX64Path} ${bunAarch64Path}`)
+  execSync(`lipo -create -output ${uvUniversal} ${uvX64Path} ${uvAarch64Path}`)
+  // also copy to generic names used at runtime
+  fs.copyFileSync(bunUniversal, path.join(BIN_DIR, 'bun'))
+  fs.copyFileSync(uvUniversal, path.join(BIN_DIR, 'uv'))
 
   // Copy architecture-specific binaries
   console.log('Copying architecture-specific binaries...')
@@ -107,6 +112,8 @@ async function handleMacOsUniversal() {
   // Set executable permissions
   fs.chmodSync(path.join(BIN_DIR, 'bun'), '755')
   fs.chmodSync(path.join(BIN_DIR, 'uv'), '755')
+  fs.chmodSync(path.join(BIN_DIR, 'bun-universal-apple-darwin'), '755')
+  fs.chmodSync(path.join(BIN_DIR, 'uv-universal-apple-darwin'), '755')
   fs.chmodSync(path.join(BIN_DIR, 'bun-aarch64-apple-darwin'), '755')
   fs.chmodSync(path.join(BIN_DIR, 'bun-x86_64-apple-darwin'), '755')
   fs.chmodSync(path.join(BIN_DIR, 'uv-aarch64-apple-darwin'), '755')


### PR DESCRIPTION
## Summary
- update macOS binary download script with universal output names
- clarify README with names of universal binaries

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file - running an install might help)*

------
https://chatgpt.com/codex/tasks/task_e_687f795a8ed8832597bb8b68085f3f7b